### PR TITLE
Account for running foundry at a sub path

### DIFF
--- a/library.js
+++ b/library.js
@@ -70,7 +70,7 @@ export default class SourceLibrary {
   static async load(systemId, selfBright, selfDim, selfItem, userLibrary, protoLight) {
     // The common library is cached - to update it, you must reload the game.
     if (!SourceLibrary.commonLibrary) {
-      SourceLibrary.commonLibrary = await fetch('/modules/torch/sources.json')
+      SourceLibrary.commonLibrary = await fetch('modules/torch/sources.json')
         .then( response => { return response.json(); });
       this.applyFieldDefaults(SourceLibrary.commonLibrary);
       }


### PR DESCRIPTION
If Foundry is running at a subpath then the `modules/torch/sources.json` won't load as the fetch assumes Foundry is running at root. This was the cause of the problems I experienced in #23