### PR TITLE
support OSE system

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -433,6 +433,50 @@
       }
     }
   },
+  "ose": {
+    "topology": "standard",
+    "quantity": "quantity.value",
+    "sources": {
+      "Torch": {
+        "type": "item",
+        "consumable": true,
+        "light": [
+          {
+            "bright": 20,
+            "dim": 30,
+            "angle": 360,
+            "color": "#ff9329",
+            "alpha": 0.5,
+            "animation": {
+              "type": "torch",
+              "speed": 5,
+              "intensity": 5,
+              "reverse": false
+            }
+          }
+        ]
+      }, 
+      "Lantern": {
+        "type": "item",
+        "consumable": false,
+        "light": [
+          {
+            "bright": 20,
+            "dim": 30,
+            "angle": 360,
+            "color": "#ff9329",
+            "alpha": 0.5,
+            "animation": {
+              "type": "torch",
+              "speed": 5,
+              "intensity": 5,
+              "reverse": false
+            }
+          }
+        ]
+      }
+    }
+  },
   "default": {
     "system": "default",
     "topology": "none",

--- a/topology.js
+++ b/topology.js
@@ -22,9 +22,9 @@ class StandardLightTopology {
     _getQuantity(item) {
       let val = item.system;
       for (const segment of this.quantityField.split(".")) {
-        val = val[path[i]];
+        val = val[segment];
       }
-      return obj;
+      return val;
     }
     _findMatchingItem(actor, lightSourceName) {
       return Array.from(actor.items).find(

--- a/topology.js
+++ b/topology.js
@@ -19,6 +19,13 @@ class StandardLightTopology {
     constructor(quantityField) {
       this.quantityField = quantityField ?? "quantity";
     }
+    _getQuantity(item) {
+      let val = item.system;
+      for (const segment of this.quantityField.split(".")) {
+        val = val[path[i]];
+      }
+      return obj;
+    }
     _findMatchingItem(actor, lightSourceName) {
       return Array.from(actor.items).find(
         (item) => item.name.toLowerCase() === lightSourceName.toLowerCase()
@@ -37,15 +44,15 @@ class StandardLightTopology {
     getInventory (actor, lightSource) {
       if (!lightSource.consumable) return;
       let item = this._findMatchingItem(actor, lightSource.name);
-      return item ? item.system[this.quantityField] : undefined;
+      return item ? this._getQuantity(item) : undefined;
     }
   
     async decrementInventory (actor, lightSource) {
       if (!lightSource.consumable) return Promise.resolve();
       let item = this._findMatchingItem(actor, lightSource.name);
-      if (item && item.system[this.quantityField] > 0) {
+      if (item && this._getQuantity(item) > 0) {
         let fieldsToUpdate = {};
-        fieldsToUpdate["system." + this.quantityField] = item.system[this.quantityField] - 1;
+        fieldsToUpdate["system." + this.quantityField] = this._getQuantity(item) - 1;
         return item.update(fieldsToUpdate);
       } else {
         return Promise.resolve();


### PR DESCRIPTION
I am trying to use this great module with the OSE system, where the quantity is not a number but an object (`{ "value": 6, "max": 6 }`)

suggested here a fix to treat quantity as a path instead of a  shallow property name, and support to the OSE system

Can't wait to use this in production :)