### PR TITLE
Fix Dragonbane lighting and change settings

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -796,10 +796,11 @@
         "consumable": false,
         "light": [
           {
-            "bright": 10,
-            "dim": 10,
+            "bright": 5,
+            "dim": 5,
             "angle": 360,
-            "alpha": 0.05,
+            "alpha": 0.1,
+            "color":"#f9f06b",
             "animation": {
               "type": "torch",
               "speed": 5,
@@ -815,10 +816,11 @@
         "consumable": false,
         "light": [
           {
-            "bright": 10,
-            "dim": 10,
+            "bright": 5,
+            "dim": 5,
             "angle": 360,
-            "alpha": 0.05,
+            "alpha": 0.1,
+            "color":"#f9f06b",
             "animation": {
               "type": "torch",
               "speed": 5,
@@ -834,10 +836,11 @@
         "consumable": false,
         "light": [
           {
-            "bright": 10,
-            "dim": 10,
+            "bright": 5,
+            "dim": 5,
             "angle": 360,
-            "alpha": 0.05,
+            "alpha": 0.1,
+            "color":"#f9f06b",
             "animation": {
               "type": "torch",
               "speed": 5,
@@ -853,14 +856,15 @@
         "consumable": false,
         "light": [
           {
-            "bright": 4,
-            "dim": 4,
+            "bright": 2,
+            "dim": 2,
             "angle": 360,
-            "alpha": 0.05,
+            "alpha": 0.1,
+            "color":"#f9f06b",
             "animation": {
               "type": "torch",
               "speed": 5,
-              "intensity": 5,
+              "intensity": 3,
               "reverse": false
             }
           }


### PR DESCRIPTION
Fixed:
1. Halved emitting range of light sources
(A square in a grid is 2x2meters in Dragonbane not 1x1meters)

Changed:
1. Set a color for the lighting to make it more realistic
2. Changed the alpha value to make sure the color is visible