### PR TITLE
Bugfix from testing with final test build of Foundry 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Middle Kingdom - v10 -> main branch
 
+### 2.21.1 - April 20, 2025 - Config Settings fix for Foundry 13
+- [BUGFIX] Adapted to support HTML changes in config settings for Foundry 13 while still supporting Foundry 12.
+
 ### 2.21.0 - April 12, 2025 - Updates for Spanish and CoC7
 - [FEATURE] Updated Spanish translations - thanks, lozonje!
 - [FEATURE] CoC7 light sources - thanks again, lozonje!

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "torch",
   "title": "Torch",
   "description": "Torch HUD Controls",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "authors": [
     {
       "name": "Deuce",
@@ -76,12 +76,12 @@
   "styles": [
     "torch.css"
   ],
-  "manifest": "https://github.com/League-of-Foundry-Developers/torch/releases/download/v2.21.0/module.json",
-  "download": "https://github.com/League-of-Foundry-Developers/torch/releases/download/v2.21.0/torch-v2.21.0.zip",
+  "manifest": "https://github.com/League-of-Foundry-Developers/torch/releases/download/v2.21.1/module.json",
+  "download": "https://github.com/League-of-Foundry-Developers/torch/releases/download/v2.21.1/torch-v2.21.1.zip",
   "url": "https://github.com/League-of-Foundry-Developers/torch",
   "compatibility": {
     "minimum": "10",
-    "verified": "13.339",
+    "verified": "13.340",
     "maximum": "13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torch",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "description": "Torch HUD Controls",
   "main": "src/torch.js",
 

--- a/test/token-tests.mjs
+++ b/test/token-tests.mjs
@@ -69,7 +69,7 @@ describe("Torch Token Tests >", () => {
       assert.ok(currentSource, "The token has a current source");
       assert.strictEqual(
         sources.length,
-        10,
+        18,
         "All the light sources came back as owned",
       );
     });


### PR DESCRIPTION
Updated logic for graying out equipment-based settings when we set "Ignore Equipment". 
It now supports applying event logic to both the V12 (app v1) and V13 (app v2) HTML structures for settings.