### PR TITLE
Feat: Add Mothership compatibility

### DIFF
--- a/src/sources.mjs
+++ b/src/sources.mjs
@@ -1143,6 +1143,69 @@ export default {
       },
     },
   },
+  "mosh": {
+    "system": "mosh",
+    "topology": "standard",
+    "quantity": "quantity",
+    "aliases": {
+      "Vaccsuit": "Flashlight",
+      "Hazard Suit": "Flashlight",
+      "Advanced Battle Dress": "Flashlight",
+      "Headlamp": "Flashlight",
+      "Glowstick": "Chemlight"
+    },
+    "sources": {
+      "Flashlight": {
+        "name": "Flashlight",
+        "type": "equipment",
+        "consumable": false,
+        "states": 2,
+        "light": [
+          {
+            "bright": 5,
+            "dim": 10,
+            "angle": 50
+          }
+        ]
+      },
+      "Lighter": {
+        "name": "Lighter",
+        "type": "equipment",
+        "consumable": false,
+        "states": 2,
+        "light": [
+          {
+            "bright": 1,
+            "dim": 3,
+            "angle": 360,
+            "color": "#ff9329",
+            "alpha": 0.5,
+            "animation": {
+              "type": "torch",
+              "speed": 5,
+              "intensity": 5,
+              "reverse": false
+            }
+          }
+        ]
+      },
+      "Chemlight": {
+        "name": "Chemlight",
+        "type": "equipment",
+        "consumable": true,
+        "states": 2,
+        "light": [
+          {
+            "bright": 1,
+            "dim": 2,
+            "angle": 360,
+            "color": "#00ff00",
+            "alpha": 0.5
+          }
+        ]
+      }
+    }
+  },
   "default": {
     "system": "default",
     "topology": "none",


### PR DESCRIPTION
Chemlight and Flashlight are in the PSG.

Vacsuit, Hazard Suit, and Advance Battle Dress all have a headlamp, presumably the same output as a flashlight.

Lighter is added since cigarettes are a thing in the PSG, and I figure they'd have a way to light them.